### PR TITLE
Turn "Spec" into a section instead of a direct link

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -91,6 +91,19 @@ ul.news li span.date:after {
 	content: " •";
 }
 
+ul.bullet-list {
+	margin: 0.5em 2.5em;
+}
+ul.bullet-list li {
+	margin-bottom: 0.25em;
+}
+ul.bullet-list li:before {
+	margin-left: -1em;
+	margin-right: 0.5em;
+	content: "▪";
+	color: #800000;
+}
+
 body, select, input, textarea {color: #333;}
 
 a {color: #800000;}

--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
 		<nav>
 			<ol>
 				<li><a href="#news">News</a></li>
-				<li><a href="https://github.com/aperezdc/hipack/blob/v1/spec.rst">Spec</a></li>
+				<li><a href="#spec">Spec</a></li>
 				<li><a href="#code">Code</a></li>
 				<li><a href="#tools">Tools</a></li>
 			</ol>
@@ -184,6 +184,25 @@
 				versions of the HiPack specification are supported by each one of them.
 			</li>
 		</ul>
+	</article>
+
+	<article>
+		<h1><a id="spec">Specifications</a></h1>
+
+		<p>HiPack specification:</p>
+		<ul class="bullet-list">
+			<li><a href="https://github.com/aperezdc/hipack/blob/v1/spec.rst">
+				HiPack Specification, version 1</a></li>
+		</ul>
+
+		<p>Enhancement proposals in consideration for the next version of the
+			specification:</p>
+		<ul class="bullet-list">
+			<li><a href="https://github.com/aperezdc/hipack/blob/gh-pages/heps/hep-001.rst">
+				HEP-001: Value Annotations</a>
+			</li>
+		</ul>
+
 	</article>
 
 	<article>


### PR DESCRIPTION
The new section contains a link to all the versions of the specification (v1
only for now), and a list of HEPs in consideration for the upcoming version.
