### PR TITLE
Add some clarifications about null values.

### DIFF
--- a/heps/hep-001.rst
+++ b/heps/hep-001.rst
@@ -8,6 +8,14 @@
 :Status: **Proposal**
 :Date: 2015/11/23
 
+
+Changelog
+=========
+
+:2022-06-24: Add considerations about null values. This change does not alter 
+             the specification, is just to clarify some obscure points.
+
+
 .. contents::
 
 
@@ -222,6 +230,20 @@ would be passed to the application as the sequence of bytes ``0xC0FEE`` and
 the (implicit) type annotation ``.int``, and in this way the information
 that the value was provided in hexadecimal form is available to the
 application.
+
+Using value annotations to generate null values
+-----------------------------------------------
+
+HiPack does not support ``null`` values natively. This is design consideration
+because the representation of a ``null`` value is different depending on the
+target language that you are using. For example in C it's a special case of
+``void *`` which indicates a non-valid pointer, in python a ``None`` means
+that some variable does not have any value, and so on. With value annotations
+you can find a suitable representation of ``null`` values with a special
+annotation, for instance: ``field::invalid ""`` could represent an invalid
+value for something that suppose to be a string. Sometimes a ``null`` means
+“generate automatically a default value”, in which case ``field::default ""``
+could be a better representation.
 
 
 Copyright

--- a/index.html
+++ b/index.html
@@ -55,13 +55,28 @@
 
 	<script type="text/javascript" src="assets/hipack.min.js"></script>
 	<script type="text/javascript">
+	function findNull(obj, out) {
+		var ret = 0;
+
+		for(i in obj) {
+			if (obj[i] === null) {
+				delete out[i];
+				ret = 1;
+			}
+			else if (typeof(obj[i]) === 'object')
+				ret = findNull(obj[i], out[i]);
+		}
+		return ret;
+	}
 	function convertHiPack() {
 		var compact = document.getElementById("try-convert-compact").checked;
 		var input = document.getElementById("try-convert-input").value;
 		var output = document.getElementById("try-convert-output");
 
 		try {
+			var orig = JSON.parse(input);
 			var data = JSON.parse(input);
+			var hasNull = findNull(orig, data);
 		} catch (e) {
 			output.value = "Error parsing JSON:\n" + e;
 			return false;
@@ -69,7 +84,21 @@
 
 		try {
 			var converted = hipack.dump(data, compact);
-		} catch (e) {
+			if (hasNull) {
+				converted += (
+					"\n\n# !!!!  WARNING   !!!!\n#" +
+					"\n# You have null values in" +
+					"\n# your origin, but HiPack" +
+					"\n# do not handle null " +
+					"\n# values by default. Read" +
+					"\n# the specification and " +
+					"\n# the HEP-001 to understand" +
+					"\n# why and how to represent" +
+					"\n# null values in HiPack.\n"
+				)
+			}
+
+	  } catch (e) {
 			output.value = "Error generating HiPack:\n" + e;
 			return false;
 		}

--- a/spec.rst
+++ b/spec.rst
@@ -5,9 +5,16 @@
 :Version: 1
 :Status: **Stable**
 :Authors: Adrián Pérez de Castro <aperez@igalia.com>,
-          Andrés J. Díaz López <ajdiaz@connectical.com>,
+          Andrés J. Díaz López <ajdiaz@ajdiaz.me>,
           Óscar García Amor <ogarcia@connectical.com>
 :Date: 2015/03/11
+
+Changelog
+=========
+
+:2022-06-24: Add considerations about null values. This change does not alter 
+             the specification, is just to clarify some obscure points.
+
 
 .. contents::
 
@@ -95,6 +102,17 @@ Note that strings may contain any arbitrary data. It is *recommended* to
 use hexadecimal escapes to encode non-printable characters (both ASCII
 and Unicode), or characters that may not be represented correctly by other
 means. Specially when messages are intended to be used by humans.
+
+Null Values
+-----------
+
+HiPack does not support null values by design. A null value could means a lot
+of things, depending on the target language. Is not easy to convert a ``null``
+to something *typable*.
+
+:💡 **Tip**: You can represent ``null`` values in a proper way
+               using value annotations, as described in
+               `HEP-001 <https://github.com/aperezdc/hipack/blob/gh-pages/heps/hep-001.rst>`_.
 
 
 Comments


### PR DESCRIPTION
This patch add clarifications about the conversion and the
implementation of null values in HiPack and in HEP-0001.
This change do not alter the specification nor the HEP, but add some
clarifications about the best way to represent null values in a
hipack file.

Because this does not change the specification, I do not create a new
spec or HEP, just amend the previous one and create a proper
changelog there.

Instead of using a `..hint::` as RST would like, because of
how (bad) GH rendering rst, I'm using a table for the hint.

Signed-off-by: Andrés J. Díaz <ajdiaz@ajdiaz.me>